### PR TITLE
Update standard-dependent-resources.bicep

### DIFF
--- a/infra/agent/standard-dependent-resources.bicep
+++ b/infra/agent/standard-dependent-resources.bicep
@@ -95,7 +95,7 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2024-06-01-preview' = 
   properties: {
     customSubDomainName: toLower('${(aiServicesName)}')
     apiProperties: {
-      statisticsEnabled: false
+      
     }
     publicNetworkAccess: 'Enabled'
   }


### PR DESCRIPTION
The API property "statisticsEnabled: false" causing deployment error for creating sources.  It is preventing running "azd provision" command. Without that property deployment works successfully.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
The property caused issue for deploying sources via "azd provision" command
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
After cloning data via azd init try to provision resources via azd provision it should not throw error anymore
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...
Make sure you can deploy sources via azd provision
## Other Information
<!-- Add any other helpful information that may be needed here. -->